### PR TITLE
flux-commands: split flux jobs section

### DIFF
--- a/_data/flux-commands.yaml
+++ b/_data/flux-commands.yaml
@@ -44,7 +44,7 @@ commands:
 
   - name: flux jobs
     groups:
-      - name: Basic interaction with jobs
+      - name: Basic job listing tool
         items:
           - title: See all my flux jobs
             command: flux jobs -a
@@ -54,6 +54,11 @@ commands:
             command: flux jobs --no-header -o '{status}:{returncode}' ƒj4CgebBV
           - title: Show me the job ids in a particular state
             command: flux jobs --filter=pending,running,inactive -o "{id}"
+
+  - name: flux job
+    groups:
+      - name: Basic interaction with jobs
+        items:
           - title: Get the ID of the last submitted job
             command: flux job last
           - title: Get the output of the last submitted job

--- a/_data/flux-commands.yaml
+++ b/_data/flux-commands.yaml
@@ -63,6 +63,8 @@ commands:
             command: flux job last
           - title: Get the output of the last submitted job
             command: flux job attach $(flux job last)
+          - title: Send a signal to a specific job
+            command: flux job kill --signal=SIGUSR1 ƒj4CgebBV
 
   - name: flux start
     groups:


### PR DESCRIPTION
flux-jobs and flux-job are two different commands but lumped
under one section.  The former is a job listing tool and the latter is
a job interaction tool.

Document flux job kill given recent user question.