### PR TITLE
typo: flux submit advanced missing --cc

### DIFF
--- a/_data/flux-commands.yaml
+++ b/_data/flux-commands.yaml
@@ -21,7 +21,7 @@ commands:
           - title: Submits scripts myscript1.sh through myscript10.sh  
             command: flux submit --cc=1-10 myscript{cc}.sh
           - title: Bypass the key value store and write output to file with jobid
-            command: flux submit --output=job-{{id}}.out ./my_super_cool_job.py
+            command: flux --cc=1-10 submit --output=job-{{id}}.out ./my_super_cool_job.py
           - title: Make a job waitable
             command: flux submit --flags waitable ./wait-for-me.sh
           - title: Wait for all jobs

--- a/_data/flux-commands.yaml
+++ b/_data/flux-commands.yaml
@@ -168,7 +168,7 @@ commands:
           - title: Do a dry run and provide multiple inputs
             command: "flux bulksubmit --dry-run /bin/bash -c 'mkdir -p ./mydir/{0}/{1}; echo created mydir/{0}/{1}' ::: a b c d ::: {1..4}"
           - title: Use carbon copy to submit identical jobs with different inputs
-            command: "flux bulksubmit --dry-run --cc={0} echo {1} ::: a b c ::: 0-1 0-3 0-7"
+            command: "flux bulksubmit --dry-run --cc={1} echo {0} ::: a b c ::: 0-1 0-3 0-7"
           - title: Similar functionality with using the seq command over a different range
             command: "flux bulksubmit echo 'Hello I am job {}' ::: $(seq 1 10)"
 


### PR DESCRIPTION
Problem: one of the examples is missing the carbon copy directive
Solution: add it, `--cc`